### PR TITLE
Added support for multiple proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ const HyperswarmClient = require('hyperswarm-proxy-ws/client')
 // Also specify any options for hyperswarm-proxy client
 // https://github.com/RangerMauve/hyperswarm-proxy#client
 const swarm = new HyperswarmClient({
-	// Specify the proxy server to connect to
-	proxy: 'ws://127.0.0.1:3472'
+  // Specify a list of proxy servers available to connect to
+	proxy: ['ws://127.0.0.1:3472']
 })
 
 // Same as with hyperswarm

--- a/client.js
+++ b/client.js
@@ -3,7 +3,7 @@ const websocket = require('websocket-stream')
 
 const DEFAULT_PORT = '4977' // HYPR on a cellphone keypad
 const LOCAL_PROXY = `ws://localhost:${DEFAULT_PORT}`
-const DEFAULT_PROXY = LOCAL_PROXY
+const DEFAULT_PROXY = [LOCAL_PROXY]
 const DEFAULT_RECONNECT_DELAY = 1000
 
 class HyperswarmProxyWSClient extends HyperswarmProxyClient {
@@ -12,13 +12,18 @@ class HyperswarmProxyWSClient extends HyperswarmProxyClient {
 
     const { proxy = DEFAULT_PROXY, reconnectDelay = DEFAULT_RECONNECT_DELAY } = opts
 
-    this.proxy = proxy
     this.reconnectDelay = reconnectDelay
+    this.proxy = null
+
+    this._urls = typeof proxy === 'string' ? [proxy] : proxy
+    this._urlIndex = 0
 
     this.reconnect()
   }
 
   reconnect () {
+    this._nextUrl();
+
     const localSocket = websocket(LOCAL_PROXY)
 
     // Re-emit errors
@@ -42,6 +47,11 @@ class HyperswarmProxyWSClient extends HyperswarmProxyClient {
       super.reconnect(proxySocket)
     })
     super.reconnect(localSocket)
+  }
+
+  _nextUrl() {
+    this.proxy = this._urls[this._urlIndex++ % this._urls.length]
+    return this.proxy
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@ test('discover and make connections', async (t) => {
 
       if (connectionCount++) return connection.end()
 
-      t.equal(swarm.proxy, proxy, 'should use the proxy working')
+      t.equal(swarm.proxy, proxy, 'should use the working proxy')
 
       t.deepEqual(info.peer.topic, TEST_TOPIC, 'got connection in client')
       connection.on('data', () => {

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ test('discover and make connections', async (t) => {
   const TEST_TOPIC = makeTopic('HYPERSWARM-PROXY-TEST' + Math.random())
   const TEST_MESSAGE = 'Hello World'
 
-  t.plan(4)
+  t.plan(5)
 
   try {
     const server = new Server()
@@ -27,7 +27,10 @@ test('discover and make connections', async (t) => {
     server.listen(port)
 
     const swarm = new Client({
-      proxy
+      proxy: [
+        'ws://localhost:4000', // wrong url
+        proxy,
+      ]
     })
 
     let connectionCount = 0
@@ -66,6 +69,8 @@ test('discover and make connections', async (t) => {
       })
 
       if (connectionCount++) return connection.end()
+
+      t.equal(swarm.proxy, proxy, 'should use the proxy working')
 
       t.deepEqual(info.peer.topic, TEST_TOPIC, 'got connection in client')
       connection.on('data', () => {


### PR DESCRIPTION
Hey @RangerMauve, how are you?

This PR adds support to have multiple proxies fallbacks, it works like a round robin. If a client cannot get a connection from the server it goes to the next one.